### PR TITLE
fix: name has changed to dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ local cmp = require("cmp")
 cmp.setup {
     sources = {
         {
-          name = "env",
+          name = "dotenv",
           -- Defaults
           option = {
             path = '.',


### PR DESCRIPTION
I had a problem with the config, but it turned out that the name was wrong.

Feel free to close this and fix this on your own.